### PR TITLE
ManualHost and SAN ManualHost renewal fixes

### DIFF
--- a/letsencrypt-win-simple/Plugin/ManualPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/ManualPlugin.cs
@@ -95,23 +95,17 @@ namespace LetsEncrypt.ACME.Simple
         }
 
         public override void Renew(Target target) {
-            string[] lsDomains = new string[0];
-
             target.Valid = false;
-            if (Program.ManualSanMode) {
-                if (target.WebRootPath == Program.Options.WebRoot) {
-                    lsDomains = Program.Options.ManualHost.Split(',');
-                    if (lsDomains.Length > 0 && lsDomains.Length <= 100) {
+            if (Program.Options.San && (target.AlternativeNames.Count > 1)) {
+                if (target.WebRootPath.Length > 0) {
                         //Check that they're the same domains
-                        target.Valid = (target.Host == lsDomains[0] &&
-                            string.Join(",", target.AlternativeNames.ToArray()) == Program.Options.ManualHost);
-                    }
+                        target.Valid = (Program.Options.ManualHost == target.Host);
                 }
 
             } else {
                 //Check the renewal relates to the CLI's host and webroot
                 target.Valid = (target.Host == Program.Options.ManualHost &&
-                                    target.WebRootPath == Program.Options.WebRoot);
+                                    target.WebRootPath.Length > 0);
             }
             if (target.Valid ) {
                 Console.WriteLine($" Processing Manual Certificate Renewal...");

--- a/letsencrypt-win-simple/Plugin/ManualPlugin.cs
+++ b/letsencrypt-win-simple/Plugin/ManualPlugin.cs
@@ -98,8 +98,8 @@ namespace LetsEncrypt.ACME.Simple
             target.Valid = false;
             if (Program.Options.San && (target.AlternativeNames.Count > 1)) {
                 if (target.WebRootPath.Length > 0) {
-                        //Check that they're the same domains
-                        target.Valid = (Program.Options.ManualHost == target.Host);
+                    //Check that they're the same domains
+                    target.Valid = (Program.Options.ManualHost.Split(',')[0] == target.AlternativeNames[0]);
                 }
 
             } else {
@@ -110,6 +110,10 @@ namespace LetsEncrypt.ACME.Simple
             if (target.Valid ) {
                 Console.WriteLine($" Processing Manual Certificate Renewal...");
                 this.Auto(target);
+            } else {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($" Ignoring Manual Certificate Renewal due to Primary Domain mismatch.");
+                Console.ResetColor();
             }
         }
 
@@ -184,6 +188,7 @@ namespace LetsEncrypt.ACME.Simple
             var directory = Path.GetDirectoryName(answerPath);
             Directory.CreateDirectory(directory);
             File.WriteAllText(answerPath, fileContents);
+
         }
     }
 }

--- a/letsencrypt-win-simple/ScheduledRenewal.cs
+++ b/letsencrypt-win-simple/ScheduledRenewal.cs
@@ -13,9 +13,8 @@ namespace LetsEncrypt.ACME.Simple
         public string Script { get; set; }
         public string ScriptParameters { get; set; }
         public bool Warmup { get; set; }
-        public string ManualHost { get; internal set; }
+        public string ManualHost { get; set; }
         public bool Renew { get; set; } = false;
-
         public override string ToString() => $"{Binding} Renew After {Date.ToShortDateString()}";
 
         internal string Save()

--- a/letsencrypt-win-simple/Target.cs
+++ b/letsencrypt-win-simple/Target.cs
@@ -30,9 +30,9 @@ namespace LetsEncrypt.ACME.Simple
         public string WebRootPath { get; set; }
         public long SiteId { get; set; }
         public List<string> AlternativeNames { get; set; }
+        public bool SAN { get; set; }
         public string PluginName { get; set; } = "IIS";
         public Plugin Plugin => Plugins[PluginName];
-
         public override string ToString() => $"{PluginName} {Host} ({WebRootPath})";
     }
 }

--- a/letsencrypt-win-simple/Target.cs
+++ b/letsencrypt-win-simple/Target.cs
@@ -30,7 +30,6 @@ namespace LetsEncrypt.ACME.Simple
         public string WebRootPath { get; set; }
         public long SiteId { get; set; }
         public List<string> AlternativeNames { get; set; }
-        public bool SAN { get; set; }
         public string PluginName { get; set; } = "IIS";
         public Plugin Plugin => Plugins[PluginName];
         public override string ToString() => $"{PluginName} {Host} ({WebRootPath})";


### PR DESCRIPTION
**Caveat: I don't have access to IIS for testing.** I attempt to keep my changes completely backwards compatible but I cannot test that completely.

I have done a lot of work around ensuring that --renew and --forcerenewal work correctly; that is the **only** parameter necessary to run the renewal process. 

Now only need a **single scheduled task** to renew all certificates granted to the client on that machine.

You may have to re-run the initial certificate request process to ensure that the registry entries are correctly populated. This *can* be tested by running with the --renew flag to see if it works.
